### PR TITLE
Fix grammar

### DIFF
--- a/keyvalues3/__init__.py
+++ b/keyvalues3/__init__.py
@@ -9,7 +9,7 @@ from .binarywriter import BinaryMagics
 from .textreader import KV3TextReader
 from . import textwriter
 
-__version__ = "0.2"
+__version__ = "0.3"
 __all__ = [ "read", "write" ]
 
 #region: read

--- a/keyvalues3/textreader.py
+++ b/keyvalues3/textreader.py
@@ -13,7 +13,7 @@ common = """
             key = (identifier / quoted_string)
 
     # TODO: only one flag
-    value_flagged = (flags ":") value
+    value_flagged = (flags ":" ws*) value
         flags = (identifier "|")* identifier
     value = null / true / false / number / multiline_string / quoted_string / dict / array / binary_blob
         null = "null"


### PR DESCRIPTION
This pull request fixes grammar, so it allows whitespaces before value
example:
```
a = subclass:  <-- keyvalues3-0.2 crashes here, because parsimonious expects value( { ) here, not whitespace( \n )
{
  b = ""
}
```